### PR TITLE
Add base paths to upload profiles. Use project base path

### DIFF
--- a/db/src/schema.rs
+++ b/db/src/schema.rs
@@ -204,6 +204,8 @@ diesel::table! {
         conversion_profile_id -> Uuid,
         updated -> Timestamptz,
         deleted -> Nullable<Timestamptz>,
+        base_storage_location_path -> Nullable<Text>,
+        output_storage_location_path -> Nullable<Text>,
     }
 }
 

--- a/db/src/upload_profiles.rs
+++ b/db/src/upload_profiles.rs
@@ -1,12 +1,11 @@
 use diesel::prelude::*;
 use serde::Deserialize;
 
+pub use crate::schema::upload_profiles::*;
 use crate::{
     object_id::{ConversionProfileId, ProjectId, StorageLocationId, TeamId, UploadProfileId},
     schema::*,
 };
-
-pub use crate::schema::upload_profiles::*;
 
 #[derive(Clone, Debug, Queryable, Insertable, Identifiable)]
 pub struct UploadProfile {
@@ -20,8 +19,12 @@ pub struct UploadProfile {
     /// Where to store the input images, since they may not want to be in the same place as the
     /// output.
     pub base_storage_location_id: StorageLocationId,
+    /// A path within the base storage location where the base image will be stored.
+    pub base_storage_location_path: String,
     /// Where to store the converted output images.
     pub output_storage_location_id: StorageLocationId,
+    /// A path within the output storage location where the output images will be stored.
+    pub output_storage_location_path: String,
     pub conversion_profile_id: ConversionProfileId,
 
     pub updated: chrono::DateTime<chrono::Utc>,

--- a/migrations/2022-07-04-014038_init/up.sql
+++ b/migrations/2022-07-04-014038_init/up.sql
@@ -57,7 +57,9 @@ CREATE TABLE upload_profiles (
   name text not null,
   short_id text,
   base_storage_location_id uuid not null references storage_locations(id) DEFERRABLE INITIALLY IMMEDIATE,
+  base_storage_location_path text,
   output_storage_location_id uuid not null references storage_locations(id) DEFERRABLE INITIALLY IMMEDIATE,
+  output_storage_location_path text,
   conversion_profile_id uuid not null references conversion_profiles(id) DEFERRABLE INITIALLY IMMEDIATE,
   updated timestamptz not null default now(),
   deleted timestamptz


### PR DESCRIPTION
Project base path was not being used. This also adds an optional base path component to the upload profile.

The image path is resolved as `{storage_location_path}/{project_base_path}/{upload_profile_path}/{image_name}`.

Resolves PIC-8